### PR TITLE
Set up services and volumes to work in the instruqt setup

### DIFF
--- a/k8s_config/monitoring/prometheus/statefulset.yml
+++ b/k8s_config/monitoring/prometheus/statefulset.yml
@@ -39,12 +39,14 @@ apiVersion: v1
 metadata:
   name: prometheus
 spec:
+  type: NodePort
   selector:
     app: prometheus-server
   ports:
   - protocol: TCP
     port: 9090
     targetPort: 9090
+    nodePort: 30001
 
 ---
 apiVersion: v1
@@ -52,13 +54,14 @@ kind: Service
 metadata:
   name: grafana
 spec:
+  type: NodePort
   ports:
     - port: 80
       protocol: TCP
       targetPort: 3000
+      nodePort: 30002
   selector:
     app: prometheus-server
-  type: LoadBalancer
 
 ---
 apiVersion: apps/v1
@@ -82,6 +85,8 @@ spec:
         runAsUser: 1000
         runAsNonRoot: true
       volumes:
+        - name: prometheus-storage-volume
+          emptyDir: {}
         - name: prometheus-config-volume
           configMap:
             defaultMode: 420
@@ -120,12 +125,3 @@ spec:
             requests:
               cpu: 100m
               memory: 100Mi
-
-  volumeClaimTemplates:
-    - metadata:
-        name: prometheus-storage-volume
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: 10Gi


### PR DESCRIPTION
Changed the services to use type NodePort so they get an IP on the machine, which can then easily be exposed in the instruqt tabs.

I also removed the persistent volume claim, since the setup does not have to be "production" worthy, just be there for the duration of the session. This simplifies the setup a little bit :)